### PR TITLE
Add PostgreSQL song database and API

### DIFF
--- a/Controllers/SongsController.cs
+++ b/Controllers/SongsController.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc;
+using MusicSite.Services;
+
+namespace MusicSite.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class SongsController : ControllerBase
+    {
+        private readonly SongService _songService;
+
+        public SongsController(SongService songService)
+        {
+            _songService = songService;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Get()
+        {
+            var songs = await _songService.GetSongsAsync();
+            return Ok(songs);
+        }
+    }
+}

--- a/Data/AppDbContext.cs
+++ b/Data/AppDbContext.cs
@@ -1,0 +1,15 @@
+using Microsoft.EntityFrameworkCore;
+using MusicSite.Models;
+
+namespace MusicSite.Data
+{
+    public class AppDbContext : DbContext
+    {
+        public AppDbContext(DbContextOptions<AppDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Song> Songs => Set<Song>();
+    }
+}

--- a/Models/Song.cs
+++ b/Models/Song.cs
@@ -1,0 +1,10 @@
+namespace MusicSite.Models
+{
+    public class Song
+    {
+        public int Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public string Artist { get; set; } = string.Empty;
+        public string FilePath { get; set; } = string.Empty;
+    }
+}

--- a/MusicSite.csproj
+++ b/MusicSite.csproj
@@ -6,4 +6,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/Program.cs
+++ b/Program.cs
@@ -1,8 +1,26 @@
+using Microsoft.EntityFrameworkCore;
+using MusicSite.Data;
+using MusicSite.Services;
+
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
+builder.Services.AddScoped<SongService>();
 
 var app = builder.Build();
 
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    db.Database.Migrate();
+    var songService = scope.ServiceProvider.GetRequiredService<SongService>();
+    await songService.SyncAsync();
+}
+
 app.UseDefaultFiles();
 app.UseStaticFiles();
+app.MapControllers();
 
 app.Run();

--- a/Services/SongService.cs
+++ b/Services/SongService.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore;
+using MusicSite.Data;
+using MusicSite.Models;
+
+namespace MusicSite.Services
+{
+    public class SongService
+    {
+        private readonly AppDbContext _dbContext;
+        private readonly string _songsDirectory;
+
+        public SongService(AppDbContext dbContext, IConfiguration configuration)
+        {
+            _dbContext = dbContext;
+            _songsDirectory =
+                Environment.GetEnvironmentVariable("SONGS_DIRECTORY") ??
+                configuration.GetValue<string>("SongsDirectory") ?? string.Empty;
+        }
+
+        public async Task SyncAsync()
+        {
+            if (string.IsNullOrWhiteSpace(_songsDirectory) || !Directory.Exists(_songsDirectory))
+            {
+                return;
+            }
+
+            var files = Directory.EnumerateFiles(_songsDirectory, "*.mp3");
+            foreach (var file in files)
+            {
+                var fileName = Path.GetFileNameWithoutExtension(file);
+                var existing = await _dbContext.Songs.FirstOrDefaultAsync(s => s.FilePath == file);
+                if (existing == null)
+                {
+                    _dbContext.Songs.Add(new Song
+                    {
+                        Title = fileName,
+                        Artist = "Unknown",
+                        FilePath = file
+                    });
+                }
+            }
+
+            await _dbContext.SaveChangesAsync();
+        }
+
+        public async Task<List<Song>> GetSongsAsync() => await _dbContext.Songs.ToListAsync();
+    }
+}

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -4,5 +4,6 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  }
+  },
+  "SongsDirectory": "D:\\Myzone"
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Database=MusicDb;Username=postgres;Password=postgres"
+  },
+  "SongsDirectory": "D:\\Myzone"
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,12 +11,18 @@
 export default {
   data() {
     return {
-      songs: [
-        { id: 1, title: 'Song A', artist: 'Artist 1' },
-        { id: 2, title: 'Song B', artist: 'Artist 2' },
-        { id: 3, title: 'Song C', artist: 'Artist 3' }
-      ]
+      songs: []
     };
+  },
+  async created() {
+    try {
+      const res = await fetch('/api/songs');
+      if (res.ok) {
+        this.songs = await res.json();
+      }
+    } catch (e) {
+      console.error(e);
+    }
   }
 };
 </script>

--- a/wwwroot/bundle.js
+++ b/wwwroot/bundle.js
@@ -186,7 +186,7 @@ eval("\nObject.defineProperty(exports, \"__esModule\", ({ value: true }));\n// r
   \*****************************************************************************************************************/
 /***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
 
-eval("__webpack_require__.r(__webpack_exports__);\n/* harmony export */ __webpack_require__.d(__webpack_exports__, {\n/* harmony export */   \"default\": () => (__WEBPACK_DEFAULT_EXPORT__)\n/* harmony export */ });\n\n/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ({\n  data() {\n    return {\n      songs: [\n        { id: 1, title: 'Song A', artist: 'Artist 1' },\n        { id: 2, title: 'Song B', artist: 'Artist 2' },\n        { id: 3, title: 'Song C', artist: 'Artist 3' }\n      ]\n    };\n  }\n});\n\n\n//# sourceURL=webpack://musicsite/./src/App.vue?./node_modules/vue-loader/dist/index.js??ruleSet%5B1%5D.rules%5B3%5D.use%5B0%5D");
+eval("__webpack_require__.r(__webpack_exports__);\n/* harmony export */ __webpack_require__.d(__webpack_exports__, {\n/* harmony export */   \"default\": () => (__WEBPACK_DEFAULT_EXPORT__)\n/* harmony export */ });\n\n/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ({\n  data() {\n    return {\n      songs: []\n    };\n  },\n  async created() {\n    try {\n      const res = await fetch('/api/songs');\n      if (res.ok) {\n        this.songs = await res.json();\n      }\n    } catch (e) {\n      console.error(e);\n    }\n  }\n});\n\n\n//# sourceURL=webpack://musicsite/./src/App.vue?./node_modules/vue-loader/dist/index.js??ruleSet%5B1%5D.rules%5B3%5D.use%5B0%5D");
 
 /***/ }),
 


### PR DESCRIPTION
## Summary
- integrate Entity Framework Core with PostgreSQL
- create `Song` model and DB context
- add service to sync songs from a configured folder
- expose `/api/songs` endpoint and use it from Vue app
- build updated frontend bundle

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f862ee7f0832fb966f773c3b63a2a